### PR TITLE
Fix wrapper restore timing and stale session handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,123 +3,84 @@
 [![AUR version](https://img.shields.io/aur/version/steam-kde-vrr-toggle)](https://aur.archlinux.org/packages/steam-kde-vrr-toggle)
 [![License: 0BSD](https://img.shields.io/badge/License-0BSD-blue.svg)](https://opensource.org/licenses/0BSD)
 
-Automatically toggles VRR / Adaptive-Sync on a per-game basis in KDE Plasma (Wayland). Solves game flickering issues by disabling VRR for specific Steam games.
+Automatically disables VRR / Adaptive Sync for selected Steam games on KDE Plasma Wayland, then restores the previous display policy when the game exits.
 
----
+## What It Does
 
-## The Problem
+Some games behave poorly with VRR enabled. This project adds a Steam launch wrapper that:
 
-Some games, particularly those running through Proton on Linux, can experience issues like flickering, stuttering, or incorrect frame pacing when Variable Refresh Rate (VRR) is enabled. Manually toggling this setting in System Settings before and after playing is tedious. This project automates that process.
+1. Captures the current VRR policy for each enabled display.
+2. Disables VRR before the game starts.
+3. Restores the original VRR policy after the game exits.
 
-## The Solution
+The wrapper runs the worker script through `systemd-run --user` so the display change happens outside the Steam runtime sandbox.
 
-This solution uses a two-script system to reliably manage display settings without being affected by the Steam runtime sandbox:
+> Important: This only changes the OS-level VRR policy. If your monitor firmware forces Adaptive-Sync on, the scripts cannot override that setting.
 
-1.  **`steam-vrr-wrapper.sh`**: A minimal wrapper script placed in the Steam game's launch options. Its only job is to use `systemd-run` to call the main worker script, ensuring it executes in a clean, non-sandboxed user session with the correct environment.
+## Improvements In v1.0.2
 
-2.  **`vrr-toggle.sh`**: The main worker script that does all the heavy lifting. It communicates directly with the KDE KScreen daemon using the `kscreen-doctor` utility and the correct `vrrpolicy` command to turn VRR off and on.
+- Waits for VRR to be disabled before launching the game.
+- Supports overlapping wrapped game sessions without restoring VRR too early.
+- Cleans up stale session markers after interrupted launches.
+- Keeps the AUR and manual-install behavior aligned with the same script paths.
 
-> **Important Disclaimer:** This script controls the VRR setting *at the Operating System level*. It will not work if your monitor's internal firmware (the On-Screen Display, or OSD) is set to override the OS preference. If your monitor's "Adaptive-Sync" or "FreeSync" setting is permanently enabled via its physical buttons, this script cannot change that.
+## Requirements
 
-## Prerequisites
-
-Your system needs the following command-line tools.
--   `bash`
--   `kscreen-doctor` (Part of KDE Plasma)
--   `jq` (A lightweight JSON processor)
--   `systemd`
+- `bash`
+- `jq`
+- `kscreen-doctor`
+- `systemd-run`
+- `flock` from `util-linux`
 
 ## Installation
 
-### Method 1: Arch User Repository (AUR) - Recommended
+### Method 1: Arch User Repository (AUR)
 
-This is the easiest and recommended method for users on Arch Linux and its derivatives (like CachyOS, Manjaro, etc.). The AUR package handles all file placement and configuration automatically.
+Install the package with your preferred AUR helper:
 
-1.  Make sure you have an AUR helper like `yay` or `paru` installed.
-2.  Install the package from the AUR:
-    ```bash
-    yay -S steam-kde-vrr-toggle
-    ```
-3.  Skip to the [Usage](#usage) section.
+```bash
+yay -S steam-kde-vrr-toggle
+```
+
+The package installs:
+
+- `steam_vrr_wrapper.sh` to `/usr/bin/steam_vrr_wrapper.sh`
+- `vrr_toggle.sh` to `/usr/lib/steam-kde-vrr-toggle/vrr_toggle.sh`
 
 ### Method 2: Manual Installation
 
-<details>
-<summary>Click here for manual installation instructions</summary>
-
-If you are not on an Arch-based distro or prefer a manual setup, follow these steps.
-
-**1. Create the Scripts**
-
-First, create a directory for your scripts if you don't have one:
-```bash
-mkdir -p ~/scripts
-```
-
-**2. Download or Create Script Files**
-
-Download the scripts directly from the repository or copy their contents.
-
-**File 1: Main Worker Script: `vrr-toggle.sh`**
-
-Download `vrr-toggle.sh` and save it to `~/scripts/vrr-toggle.sh`.
-Alternatively, copy the content from [vrr-toggle.sh](./vrr_toggle.sh) in this repository.
-
-**File 2: Steam Wrapper Script: `steam_vrr_wrapper.sh`**
-
-Download `steam_vrr_wrapper.sh` and save it to `~/scripts/steam_vrr_wrapper.sh`.
-Alternatively, copy the content from [steam_vrr_wrapper.sh](./steam_vrr_wrapper.sh) in this repository.
-
-**3. Make Scripts Executable**
+Place both scripts somewhere permanent, then make them executable:
 
 ```bash
-chmod +x ~/scripts/vrr_toggle.sh && chmod +x ~/scripts/steam-vrr-wrapper.sh
+chmod +x /absolute/path/to/vrr_toggle.sh /absolute/path/to/steam_vrr_wrapper.sh
 ```
 
-**4. Configure the Wrapper**
-
-Open the `steam_vrr_wrapper.sh` file with a text editor and **replace `YOUR_USER`** with your actual Linux username (if you are not using the default `/usr/bin/` location).
-```bash
-kate ~/scripts/steam-vrr-wrapper.sh
-```
-
-</details>
+If you are not using the packaged path, point the wrapper at the worker script with `MAIN_SCRIPT_PATH`.
 
 ## Usage
 
-1.  In your Steam Library, right-click the game you want to manage.
-2.  Select **Properties...**.
-3.  In the **GENERAL** tab, find the **LAUNCH OPTIONS** text box.
-4.  Enter the command based on your installation method:
+In the Steam game's launch options, use one of these commands.
 
-    #### If installed from the AUR:
-    The scripts are in your system's PATH, so no full path is needed.
-    ```
-    steam-vrr-wrapper.sh %command%
-    ```
+### If installed from the AUR
 
-    #### If installed manually:
-    You must provide the full path to the wrapper script. Remember to replace `YOUR_USER`.
-    ```
-    /home/YOUR_USER/scripts/steam-vrr-wrapper.sh %command%
-    ```
+```bash
+steam_vrr_wrapper.sh %command%
+```
 
-5.  Close the Properties window. That's it! If your monitor respects OS-level VRR commands, your screen should flicker as the mode is turned off and on.
+### If installed manually
+
+```bash
+MAIN_SCRIPT_PATH="/absolute/path/to/vrr_toggle.sh" /absolute/path/to/steam_vrr_wrapper.sh %command%
+```
 
 ## Troubleshooting
 
-### Checking the Log
+If the wrapper cannot toggle VRR, it logs a warning and still launches the game.
 
-The script's actions are logged to the systemd journal. If you suspect an issue, you can check its log. Open a terminal and run this command to see recent logs from the script:
+To inspect recent worker logs:
 
 ```bash
-journalctl --user -u "vrr-toggle.sh" --since "5 minutes ago"
+journalctl --user --since "10 minutes ago" | grep "VRR_TOGGLE"
 ```
-If the log shows the `EXECUTING` and `RESTORING` messages without any errors, the script is working correctly from a software perspective.
 
-### No Screen Flicker / Setting Doesn't Change
-
-If the journal shows the script is working but you see no physical change on your screen, it is almost certain that your **monitor's internal firmware is overriding the command from the OS.**
-
-*   **The Cause:** Many monitors have a primary "Adaptive-Sync" or "FreeSync" setting in their On-Screen Display (OSD) menu (the menu you access with the physical buttons on the monitor). If this is set to "On", it may ignore any requests from the operating system to turn it off.
-*   **The Solution:** Use the physical buttons on your monitor to open its OSD menu, navigate to the "Gaming" or "System" section, and ensure the master Adaptive-Sync setting is set to a state that allows OS control, which may be labeled "Off" or "Standard". The ideal scenario is when toggling the setting in KDE's System Settings causes a screen flicker, which confirms the OS has control.
+If the scripts log successful changes but the monitor never flickers or updates, check the monitor OSD and make sure its Adaptive-Sync setting allows OS control.

--- a/steam_vrr_wrapper.sh
+++ b/steam_vrr_wrapper.sh
@@ -1,40 +1,63 @@
 #!/bin/bash
 
-# Default path if installed via AUR/package
-MAIN_SCRIPT_PATH="/usr/bin/vrr_toggle.sh"
+set -u
 
-# If not found, try to look for it in local scripts or current path
-if [ ! -f "$MAIN_SCRIPT_PATH" ]; then
-    # Fallback/User Configuration: Set the full path to your script if it's not in /usr/bin
-    # MAIN_SCRIPT_PATH="/home/YOUR_USER/scripts/vrr_toggle.sh"
+MAIN_SCRIPT_PATH="${MAIN_SCRIPT_PATH:-/usr/bin/vrr_toggle.sh}"
+SESSION_ID="steam-vrr-$$-${RANDOM}"
+RESTORE_NEEDED=0
 
-    # Check if we can find it in the same directory as this wrapper?
-    # Or just fail if not configured.
-    if [ -f "$HOME/scripts/vrr_toggle.sh" ]; then
-        MAIN_SCRIPT_PATH="$HOME/scripts/vrr_toggle.sh"
-    fi
-fi
+log() {
+	printf '[STEAM_VRR_WRAPPER] %s\n' "$1" >&2
+}
 
-if [ ! -f "$MAIN_SCRIPT_PATH" ]; then
-    echo "Error: vrr_toggle.sh not found at $MAIN_SCRIPT_PATH"
-    echo "Please configure MAIN_SCRIPT_PATH in steam_vrr_wrapper.sh"
-    exit 1
-fi
+run_toggle() {
+	local action="$1"
 
-systemd-run \
-    --user \
-    --no-block \
-    --setenv=WAYLAND_DISPLAY="$WAYLAND_DISPLAY" \
-    --setenv=XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
-    --setenv=DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" \
-    "$MAIN_SCRIPT_PATH" off
+	systemd-run \
+		--user \
+		--wait \
+		--collect \
+		--quiet \
+		--setenv=STEAM_VRR_WRAPPER_PID="$$" \
+		--setenv=WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-}" \
+		--setenv=XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-}" \
+		--setenv=DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-}" \
+		"$MAIN_SCRIPT_PATH" "$action" "$SESSION_ID"
+}
 
-"$@"
+cleanup() {
+	local exit_status=$?
 
-systemd-run \
-    --user \
-    --no-block \
-    --setenv=WAYLAND_DISPLAY="$WAYLAND_DISPLAY" \
-    --setenv=XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
-    --setenv=DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" \
-    "$MAIN_SCRIPT_PATH" restore
+	trap - EXIT INT TERM
+
+	if ((RESTORE_NEEDED)); then
+		if ! run_toggle restore; then
+			log "Failed to restore VRR state"
+		fi
+	fi
+
+	exit "$exit_status"
+}
+
+main() {
+	if [[ $# -eq 0 ]]; then
+		log "No game command was provided"
+		exit 64
+	fi
+
+	if [[ ! -x "$MAIN_SCRIPT_PATH" ]]; then
+		log "Main script not found or not executable: $MAIN_SCRIPT_PATH"
+		exec "$@"
+	fi
+
+	if run_toggle off; then
+		RESTORE_NEEDED=1
+	else
+		log "Failed to disable VRR before launch; continuing without changes"
+	fi
+
+	trap cleanup EXIT INT TERM
+	"$@"
+}
+
+main "$@"

--- a/steam_vrr_wrapper.sh
+++ b/steam_vrr_wrapper.sh
@@ -2,7 +2,7 @@
 
 set -u
 
-MAIN_SCRIPT_PATH="${MAIN_SCRIPT_PATH:-/usr/bin/vrr_toggle.sh}"
+MAIN_SCRIPT_PATH="${MAIN_SCRIPT_PATH:-/usr/lib/steam-kde-vrr-toggle/vrr_toggle.sh}"
 SESSION_ID="steam-vrr-$$-${RANDOM}"
 RESTORE_NEEDED=0
 

--- a/vrr_toggle.sh
+++ b/vrr_toggle.sh
@@ -57,8 +57,15 @@ restore_vrr() {
 
 	while IFS= read -r output_name original_vrr_policy; do
 		[[ "$original_vrr_policy" != "null" ]] || continue
-		printf '[VRR_TOGGLE] Restoring %s to %s\n' "$output_name" "$original_vrr_policy"
-		"$KS_CMD" "output.${output_name}.vrrpolicy.${original_vrr_policy}"
+		local policy_str
+		case "$original_vrr_policy" in
+			0) policy_str="never" ;;
+			1) policy_str="always" ;;
+			2) policy_str="automatic" ;;
+			*) policy_str="$original_vrr_policy" ;;
+		esac
+		printf '[VRR_TOGGLE] Restoring %s to %s\n' "$output_name" "$policy_str"
+		"$KS_CMD" "output.${output_name}.vrrpolicy.${policy_str}"
 	done < <("$JQ_CMD" -r '.outputs[] | select(.enabled == true) | "\(.name) \(.vrrpolicy)"' <"$state_file")
 }
 

--- a/vrr_toggle.sh
+++ b/vrr_toggle.sh
@@ -1,78 +1,122 @@
 #!/bin/bash
 
+set -euo pipefail
+
 KS_CMD="/usr/bin/kscreen-doctor"
 JQ_CMD="/usr/bin/jq"
+FLOCK_CMD="/usr/bin/flock"
 
-STATE_FILE="/tmp/vrr_original_states.json"
+STATE_ROOT="${XDG_RUNTIME_DIR:-/tmp}/steam-kde-vrr-toggle"
+LOCK_FILE="$STATE_ROOT/lock"
+SESSIONS_DIR="$STATE_ROOT/sessions"
+ORIGINAL_STATE_FILE="$STATE_ROOT/original-state.json"
 
+usage() {
+	printf 'Usage: %s {off|restore} SESSION_ID\n' "$0" >&2
+	exit 64
+}
 
-case "$1" in
-    off)
-        echo "[VRR_TOGGLE] Disabling VRR..."
+require_command() {
+	if [[ ! -x "$1" ]]; then
+		printf '[VRR_TOGGLE] Missing required executable: %s\n' "$1" >&2
+		exit 69
+	fi
+}
 
-        # Capture current state to a temp file first
-        TEMP_STATE=$(mktemp)
-        if ! $KS_CMD -j > "$TEMP_STATE"; then
-            echo "[VRR_TOGGLE] Error: Failed to query kscreen-doctor state."
-            rm -f "$TEMP_STATE"
-            exit 1
-        fi
+session_file() {
+	printf '%s/%s.state' "$SESSIONS_DIR" "$1"
+}
 
-        # Validate JSON content
-        if ! $JQ_CMD . "$TEMP_STATE" >/dev/null 2>&1; then
-            echo "[VRR_TOGGLE] Error: Invalid JSON output from kscreen-doctor."
-            rm -f "$TEMP_STATE"
-            exit 1
-        fi
+prune_stale_sessions() {
+	shopt -s nullglob
+	local session_files=("$SESSIONS_DIR"/*.state)
+	shopt -u nullglob
+	local session_file owner_pid
 
-        # Move valid state to persistent location
-        mv "$TEMP_STATE" "$STATE_FILE"
+	for session_file in "${session_files[@]}"; do
+		owner_pid="$(<"$session_file")"
 
-        while read -r output_name; do
-            echo "[VRR_TOGGLE] EXECUTING: $KS_CMD output.${output_name}.vrrpolicy.never"
-            if ! $KS_CMD "output.${output_name}.vrrpolicy.never"; then
-                echo "[VRR_TOGGLE] Error: Failed to disable VRR for $output_name"
-                # We continue to try other outputs, but exit with error at the end?
-                # Or exit immediately? The comment says "abort with a clear error".
-                # But we might have partially applied changes.
-                # For now, let's just log it. The wrapper calls this asynchronously anyway.
-                exit 1
-            fi
-        done < <($JQ_CMD -r '.outputs[] | select(.enabled==true) | .name' < "$STATE_FILE")
-        ;;
+		if [[ ! "$owner_pid" =~ ^[0-9]+$ ]] || ! kill -0 "$owner_pid" 2>/dev/null; then
+			rm -f "$session_file"
+		fi
+	done
+}
 
-    restore)
-        if [[ -f "$STATE_FILE" ]]; then
-            echo "[VRR_TOGGLE] Restoring VRR..."
-            RESTORE_SUCCESS=true
+disable_vrr() {
+	local state_file="$1"
 
-            while read -r output_name original_vrr_policy; do
-                if [[ "$original_vrr_policy" != "null" ]]; then
-                    # Map integer values to strings if necessary
-                    case "$original_vrr_policy" in
-                        0) policy_str="never" ;;
-                        1) policy_str="always" ;;
-                        2) policy_str="automatic" ;;
-                        *) policy_str="$original_vrr_policy" ;; # Fallback for existing string values
-                    esac
+	while IFS= read -r output_name; do
+		[[ -n "$output_name" ]] || continue
+		printf '[VRR_TOGGLE] Disabling VRR on %s\n' "$output_name"
+		"$KS_CMD" "output.${output_name}.vrrpolicy.off"
+	done < <("$JQ_CMD" -r '.outputs[] | select(.enabled == true) | .name' <"$state_file")
+}
 
-                    echo "[VRR_TOGGLE] RESTORING: $KS_CMD output.${output_name}.vrrpolicy.${policy_str}"
-                    if ! $KS_CMD "output.${output_name}.vrrpolicy.${policy_str}"; then
-                        echo "[VRR_TOGGLE] Error: Failed to restore VRR for $output_name"
-                        RESTORE_SUCCESS=false
-                    fi
-                fi
-            done < <($JQ_CMD -r '.outputs[] | select(.enabled==true) | "\(.name) \(.vrrpolicy)"' < "$STATE_FILE")
+restore_vrr() {
+	local state_file="$1"
 
-            if [ "$RESTORE_SUCCESS" = true ]; then
-                rm "$STATE_FILE"
-                echo "[VRR_TOGGLE] Restoration complete."
-            else
-                echo "[VRR_TOGGLE] Warning: Restoration failed for some outputs. State file preserved."
-                exit 1
-            fi
-        else
-            echo "[VRR_TOGGLE] No state file found. Nothing to restore."
-        fi
-        ;;
-esac
+	while IFS= read -r output_name original_vrr_policy; do
+		[[ "$original_vrr_policy" != "null" ]] || continue
+		printf '[VRR_TOGGLE] Restoring %s to %s\n' "$output_name" "$original_vrr_policy"
+		"$KS_CMD" "output.${output_name}.vrrpolicy.${original_vrr_policy}"
+	done < <("$JQ_CMD" -r '.outputs[] | select(.enabled == true) | "\(.name) \(.vrrpolicy)"' <"$state_file")
+}
+
+has_active_sessions() {
+	shopt -s nullglob
+	local session_files=("$SESSIONS_DIR"/*.state)
+	shopt -u nullglob
+	((${#session_files[@]} > 0))
+}
+
+main() {
+	local action="${1:-}"
+	local session_id="${2:-}"
+
+	[[ -n "$action" && -n "$session_id" ]] || usage
+	[[ "$session_id" =~ ^[A-Za-z0-9._-]+$ ]] || {
+		printf '[VRR_TOGGLE] Invalid session id: %s\n' "$session_id" >&2
+		exit 64
+	}
+
+	require_command "$KS_CMD"
+	require_command "$JQ_CMD"
+	require_command "$FLOCK_CMD"
+
+	mkdir -p "$SESSIONS_DIR"
+	exec 9>"$LOCK_FILE"
+	"$FLOCK_CMD" 9
+	prune_stale_sessions
+
+	local current_session_file
+	current_session_file="$(session_file "$session_id")"
+
+	case "$action" in
+	off)
+		if [[ ! -f "$ORIGINAL_STATE_FILE" ]]; then
+			local pending_state_file
+			pending_state_file="$STATE_ROOT/original-state.json.$$.tmp"
+
+			printf '[VRR_TOGGLE] Capturing current VRR state\n'
+			"$KS_CMD" -j >"$pending_state_file"
+			disable_vrr "$pending_state_file"
+			mv "$pending_state_file" "$ORIGINAL_STATE_FILE"
+		fi
+
+		printf '%s\n' "${STEAM_VRR_WRAPPER_PID:-}" >"$current_session_file"
+		;;
+	restore)
+		rm -f "$current_session_file"
+
+		if [[ -f "$ORIGINAL_STATE_FILE" ]] && ! has_active_sessions; then
+			restore_vrr "$ORIGINAL_STATE_FILE"
+			rm -f "$ORIGINAL_STATE_FILE"
+		fi
+		;;
+	*)
+		usage
+		;;
+	esac
+}
+
+main "$@"

--- a/vrr_toggle.sh
+++ b/vrr_toggle.sh
@@ -48,7 +48,7 @@ disable_vrr() {
 	while IFS= read -r output_name; do
 		[[ -n "$output_name" ]] || continue
 		printf '[VRR_TOGGLE] Disabling VRR on %s\n' "$output_name"
-		"$KS_CMD" "output.${output_name}.vrrpolicy.off"
+		"$KS_CMD" "output.${output_name}.vrrpolicy.never"
 	done < <("$JQ_CMD" -r '.outputs[] | select(.enabled == true) | .name' <"$state_file")
 }
 


### PR DESCRIPTION
## Summary
- make the Steam wrapper wait for VRR disable before launching and always attempt restore on exit
- track active wrapper sessions under a lock so overlapping launches do not clobber or prematurely restore shared VRR state
- update the README to match the actual AUR/manual install paths and document the new behavior

## Validation
- `bash -n steam_vrr_wrapper.sh`
- `bash -n vrr_toggle.sh`
